### PR TITLE
manifest input type fix

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,6 +1,6 @@
 import { Manifest, PageProps, h } from "./deps.ts";
 import { buildTrie, getRouteInfoBranch } from "./trie.ts";
-import { Layout, Module, Page, RouteInfo } from "./types.ts";
+import { Layout, LayoutManifest, LayoutModule, Page, RouteInfo } from "./types.ts";
 import { isMiddleware, is404, is500, isApp, isLayout } from "./utils.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -26,7 +26,7 @@ export const useLayout = (layout: Layout|any) => {
   };
 }
 
-export const applyManifestLayouts = (manifest: Manifest): Manifest => {
+export const applyManifestLayouts = (manifest: LayoutManifest): Manifest => {
   const layoutRoutes: RouteInfo[] = [];
   const pageRoutes: RouteInfo[] = [];
   // deno-lint-ignore no-explicit-any
@@ -47,11 +47,11 @@ export const applyManifestLayouts = (manifest: Manifest): Manifest => {
       const module = mod as {config?: {layout: Layout}, default: Layout|any};
       if(module.config?.layout) {
         const routeDir = route.slice(0, i);
-        const layoutModule = {default: useLayout(module.config.layout)} as Module
+        const layoutModule = {default: useLayout(module.config.layout)} as LayoutModule;
         layoutRoutes.push({ path: routeDir, module: layoutModule});
       }
     } else {
-      const module = mod as Module;
+      const module = mod as LayoutModule;
       if (module.default) {
         if (isLayout(routeFileName)) {
           const routeDir = route.slice(0, i);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { JSX, PageProps } from "./deps.ts";
+import { JSX, Manifest, PageProps } from "./deps.ts";
 
 // deno-lint-ignore no-explicit-any
 export type Page<Data = any> = (props?: PageProps<Data>) => JSX.Element;
@@ -9,11 +9,18 @@ export type Layout<Data = any> = (
   props?: PageProps<Data>
 ) => JSX.Element;
 
-export interface Module {
+export interface LayoutModule {
   default?: Page | Layout;
 }
 
 export interface RouteInfo {
   path: string;
-  module: Module;
+  module: LayoutModule;
+}
+
+export interface LayoutManifest extends Omit<Manifest, "routes"> {
+  routes: Record<
+    string,
+    Manifest["routes"] extends infer R ? R | LayoutModule : never
+  >;
 }


### PR DESCRIPTION
I noticed that where `applyManifestLayouts(manifest)` is called, it's expecting manifest to be of type manifest, but `_layout.tsx` doesn't conform to this type, so I've just extended the Manifest type to be LayoutManifest.

Also renamed `Module` to `LayoutModule`